### PR TITLE
add hyperrefs to citations

### DIFF
--- a/whitepaper.tex
+++ b/whitepaper.tex
@@ -32,6 +32,8 @@ hyperref=auto,
 %
 \addbibresource{ref.bib} % Hier Pfad zu deiner .bib-Datei hineinschreiben
 \nocite{*} % Alle Einträge in der .bib-Datei im Literaturverzeichnis ausgeben, auch wenn sie nicht im Text zitiert werden. Gut zum Testen der .bib-Datei, sollte aber nicht generell verwendet werden. Stattdessen lieber gezielt Einträge mit Keywords ausgeben lassen (siehe \printbibliography in Zeile 224).
+
+\usepackage{hyperref}
 %
 % TITLE
 \title{Decentral Card Network}


### PR DESCRIPTION
fixes #2 

Overleaf doc states: One must be careful when importing hyperref: usually, it has to be the last package to be imported—but there might be some exceptions to this rule. 
c.f. https://www.overleaf.com/learn/latex/Hyperlinks#Introduction